### PR TITLE
Fix matching params in url with words between them

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -69,7 +69,11 @@ function isRouteNotEmpty(route: string): boolean {
 }
 
 function isParamsNameInUrl(route: string, params: Record<string, string>): boolean {
-    const routeParts = route.split('/:')
+    const routeParts = route
+      .split('/')
+      .filter(path => path[0] === ':')
+      .map(path => path.substr(1));
+
     return Object.keys(params).every(param => {
         return routeParts.includes(param)
     })


### PR DESCRIPTION
Hello, firstly I would like to thank you for this great library.

My pull request fix problem in checking if params are inside URL.

For example: `country/:id/location/:locationId` will fail due to splitting only by `/:` (resulting `routeParts` variable is `['country', 'id/location', 'locationId' ]`.